### PR TITLE
Remove specific markdown file exclusions from markdownlint configuration

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -2,8 +2,6 @@
     "gitignore": true,
     "globs": [
         "*.md",
-        "**/*.md",
-        "!**/.github/ISSUE_TEMPLATE/**/*.md",
-        "!**/.github/pull_request_template.md"
+        "**/*.md"
     ]
 }


### PR DESCRIPTION
This pull request includes a small change to the `.markdownlint-cli2.jsonc` file. The change simplifies the glob patterns used for markdown files by removing specific exclusions. 

* [`.markdownlint-cli2.jsonc`](diffhunk://#diff-4929acf5ce7500ed4d3f00992a1c918e702427b7857fed53152e48fd58c2ae9cL5-R5): Simplified the glob patterns by removing exclusions for `.github/ISSUE_TEMPLATE` and `.github/pull_request_template.md` files.