### PR TITLE
翻訳プロセスの大枠を作成する

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="xunit.v3" Version="2.0.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
   </ItemGroup>

--- a/src/TsunaCan.XmlDocumentationTranslator.Core/ITranslator.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.Core/ITranslator.cs
@@ -12,15 +12,14 @@ public interface ITranslator
     /// <summary>
     ///  Translates the XML documentation file to a different languages.
     /// </summary>
-    /// <param name="document">Source IntelliSense document.</param>
+    /// <param name="document">Source IntelliSense document accessor.</param>
     /// <param name="sourceLanguage">Source document language.</param>
     /// <param name="targetLanguages"> Target document languages.</param>
     /// <returns>Translated IntelliSense documents.</returns>
     /// <exception cref="ArgumentException">
     ///  <list type="bullet">
-    ///   <item>Culture is not invaliant culture.</item>
     ///   <item><paramref name="targetLanguages"/> is empty.</item>
     ///  </list>
     /// </exception>
-    Task<Dictionary<CultureInfo, IntelliSenseDocument>> TranslateAsync(XDocument document, CultureInfo sourceLanguage, IEnumerable<CultureInfo> targetLanguages);
+    Task<Dictionary<CultureInfo, IntelliSenseDocument>> TranslateAsync(IntelliSenseDocumentAccessor document, CultureInfo sourceLanguage, IEnumerable<CultureInfo> targetLanguages);
 }

--- a/src/TsunaCan.XmlDocumentationTranslator.Core/ITranslator.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.Core/ITranslator.cs
@@ -1,0 +1,26 @@
+﻿using System.Globalization;
+using System.Xml.Linq;
+using TsunaCan.XmlDocumentationTranslator.IntelliSense;
+
+namespace TsunaCan.XmlDocumentationTranslator;
+
+/// <summary>
+///  Interface for translating XML documentation files.
+/// </summary>
+public interface ITranslator
+{
+    /// <summary>
+    ///  Translates the XML documentation file to a different languages.
+    /// </summary>
+    /// <param name="document">Source IntelliSense document.</param>
+    /// <param name="sourceLanguage">Source document language.</param>
+    /// <param name="targetLanguages"> Target document languages.</param>
+    /// <returns>Translated IntelliSense documents.</returns>
+    /// <exception cref="ArgumentException">
+    ///  <list type="bullet">
+    ///   <item>Culture is not invaliant culture.</item>
+    ///   <item><paramref name="targetLanguages"/> is empty.</item>
+    ///  </list>
+    /// </exception>
+    Task<Dictionary<CultureInfo, IntelliSenseDocument>> TranslateAsync(XDocument document, CultureInfo sourceLanguage, IEnumerable<CultureInfo> targetLanguages);
+}

--- a/src/TsunaCan.XmlDocumentationTranslator.Core/IntelliSense/IIntelliSenseDocumentManager.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.Core/IntelliSense/IIntelliSenseDocumentManager.cs
@@ -1,0 +1,26 @@
+﻿namespace TsunaCan.XmlDocumentationTranslator.IntelliSense;
+
+/// <summary>
+///  Interface of manages the reading and writing of IntelliSense XML documentation files.
+/// </summary>
+public interface IIntelliSenseDocumentManager
+{
+    /// <summary>
+    ///  Reads an IntelliSense XML documentation file and deserializes it into an <see cref="IntelliSenseDocument"/> object.
+    /// </summary>
+    /// <param name="intelliSenseDocumentPath">The path to the IntelliSense XML documentation file.</param>
+    /// <returns><see cref="IntelliSenseDocumentAccessor"/> object.</returns>
+    IntelliSenseDocumentAccessor Read(string intelliSenseDocumentPath);
+
+    /// <summary>
+    ///  Writes an <see cref="IntelliSenseDocument"/> object to an XML file.
+    /// </summary>
+    /// <param name="outputFilePath">The path to the output XML file.</param>
+    /// <param name="document">The <see cref="IntelliSenseDocument"/> object to serialize and write.</param>
+    /// <exception cref="ArgumentException">
+    ///  <list type="bullet">
+    ///   <item>Thrown if <paramref name="outputFilePath"/> is null or empty.</item>
+    ///  </list>
+    /// </exception>
+    void Write(string outputFilePath, IntelliSenseDocument document);
+}

--- a/src/TsunaCan.XmlDocumentationTranslator.Core/IntelliSense/IntelliSenseDocumentAccessor.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.Core/IntelliSense/IntelliSenseDocumentAccessor.cs
@@ -5,7 +5,7 @@ namespace TsunaCan.XmlDocumentationTranslator.IntelliSense;
 /// <summary>
 ///  IntelliSense XML documentation file accessor.
 /// </summary>
-internal class IntelliSenseDocumentAccessor
+public class IntelliSenseDocumentAccessor
 {
     private readonly XDocument document;
 
@@ -13,21 +13,21 @@ internal class IntelliSenseDocumentAccessor
     /// Initializes a new instance of the <see cref="IntelliSenseDocumentAccessor"/> class.
     /// </summary>
     /// <param name="document"><see cref="XDocument"/> object.</param>
-    internal IntelliSenseDocumentAccessor(XDocument document)
+    public IntelliSenseDocumentAccessor(XDocument document)
         => this.document = document;
 
     /// <summary>
     /// Gets the assembly name element value from the XML document.
     /// </summary>
     /// <returns>Assembly name.</returns>
-    internal string GetAssemblyName()
+    public string GetAssemblyName()
         => this.document.Root?.Element(Constants.AssemblyElement)?.Element(Constants.NameElement)?.Value ?? string.Empty;
 
     /// <summary>
     /// Gets the member elements xml string list from the XML document.
     /// </summary>
     /// <returns>Member elements xml string list.</returns>
-    internal IEnumerable<string> GetMembers()
+    public IEnumerable<string> GetMembers()
         => this.document.Descendants(Constants.MemberElement)
             .Select(m => m.ToString(SaveOptions.DisableFormatting)); // get member element xml string.
 }

--- a/src/TsunaCan.XmlDocumentationTranslator.Core/IntelliSense/IntelliSenseDocumentManager.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.Core/IntelliSense/IntelliSenseDocumentManager.cs
@@ -10,7 +10,7 @@ namespace TsunaCan.XmlDocumentationTranslator.IntelliSense;
 /// <summary>
 ///  Manages the reading and writing of IntelliSense XML documentation files.
 /// </summary>
-public class IntelliSenseDocumentManager
+public class IntelliSenseDocumentManager : IIntelliSenseDocumentManager
 {
     private readonly XmlSerializer serializer;
     private readonly ILogger<IntelliSenseDocumentManager> logger;
@@ -37,7 +37,7 @@ public class IntelliSenseDocumentManager
     ///   <item>Thrown if <paramref name="intelliSenseDocumentPath"/> file is empty.</item>
     ///  </list>
     /// </exception>
-    internal IntelliSenseDocumentAccessor Read(string intelliSenseDocumentPath)
+    public IntelliSenseDocumentAccessor Read(string intelliSenseDocumentPath)
     {
         this.logger.LogDebug(Messages.XmlDocumentLoading, intelliSenseDocumentPath);
 
@@ -63,7 +63,7 @@ public class IntelliSenseDocumentManager
     ///   <item>Thrown if <paramref name="outputFilePath"/> is null or empty.</item>
     ///  </list>
     /// </exception>
-    internal void Write(string outputFilePath, IntelliSenseDocument document)
+    public void Write(string outputFilePath, IntelliSenseDocument document)
     {
         ArgumentException.ThrowIfNullOrEmpty(outputFilePath);
         this.logger.LogInformation(Messages.XmlDocumentCreating, outputFilePath);

--- a/src/TsunaCan.XmlDocumentationTranslator.Core/IntelliSense/IntelliSenseDocumentManager.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.Core/IntelliSense/IntelliSenseDocumentManager.cs
@@ -66,6 +66,7 @@ public class IntelliSenseDocumentManager
     internal void Write(string outputFilePath, IntelliSenseDocument document)
     {
         ArgumentException.ThrowIfNullOrEmpty(outputFilePath);
+        this.logger.LogInformation(Messages.XmlDocumentCreating, outputFilePath);
 
         // Ensure the directory exists
         var directory = Path.GetDirectoryName(outputFilePath);

--- a/src/TsunaCan.XmlDocumentationTranslator.Core/Resources/Messages.Designer.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.Core/Resources/Messages.Designer.cs
@@ -70,11 +70,29 @@ namespace TsunaCan.XmlDocumentationTranslator.Resources {
         }
         
         /// <summary>
+        ///   Setting variavles: {Variables} に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string DumpSettings {
+            get {
+                return ResourceManager.GetString("DumpSettings", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   XML string is invalid. に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string InvalidXmlString {
             get {
                 return ResourceManager.GetString("InvalidXmlString", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   The following {OutputFileCount} files were output: {OutputFiles} に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string Translated {
+            get {
+                return ResourceManager.GetString("Translated", resourceCulture);
             }
         }
         
@@ -93,6 +111,15 @@ namespace TsunaCan.XmlDocumentationTranslator.Resources {
         internal static string XmlDocumentCreated {
             get {
                 return ResourceManager.GetString("XmlDocumentCreated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Xml document {OutputFileName} is now creating. に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string XmlDocumentCreating {
+            get {
+                return ResourceManager.GetString("XmlDocumentCreating", resourceCulture);
             }
         }
         

--- a/src/TsunaCan.XmlDocumentationTranslator.Core/Resources/Messages.resx
+++ b/src/TsunaCan.XmlDocumentationTranslator.Core/Resources/Messages.resx
@@ -120,14 +120,23 @@
   <data name="DirectoryCreated" xml:space="preserve">
     <value>Directory {directory} was created.</value>
   </data>
+  <data name="DumpSettings" xml:space="preserve">
+    <value>Setting variavles: {Variables}</value>
+  </data>
   <data name="InvalidXmlString" xml:space="preserve">
     <value>XML string is invalid.</value>
+  </data>
+  <data name="Translated" xml:space="preserve">
+    <value>The following {OutputFileCount} files were output: {OutputFiles}</value>
   </data>
   <data name="UnableToConvertObjectToXml" xml:space="preserve">
     <value>Unable to convert object to XML.</value>
   </data>
   <data name="XmlDocumentCreated" xml:space="preserve">
     <value>Xml document {OutputFileName} was created.</value>
+  </data>
+  <data name="XmlDocumentCreating" xml:space="preserve">
+    <value>Xml document {OutputFileName} is now creating.</value>
   </data>
   <data name="XmlDocumentLoaded" xml:space="preserve">
     <value>'{XmlDocumentPath}' file was loaded.</value>

--- a/src/TsunaCan.XmlDocumentationTranslator.Core/Settings.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.Core/Settings.cs
@@ -16,22 +16,22 @@ public class Settings
     /// <summary>
     ///  Gets or sets the path to the IntelliSense document.
     /// </summary>
-    public required string IntelliSenseDocumentPath { get; set; }
+    public required string SourceDocumentPath { get; set; }
 
     /// <summary>
-    ///  Gets or sets the locale of the IntelliSense document.
+    ///  Gets or sets the language of the IntelliSense document.
     /// </summary>
-    public required CultureInfo IntelliSenseDocumentLocale { get; set; }
+    public required CultureInfo SourceDocumentLanguage { get; set; }
 
     /// <summary>
-    ///  Gets or sets the output file path.
+    ///  Gets or sets the output directory path.
     /// </summary>
-    public required string OutputFilePath { get; set; }
+    public required string OutputDirectoryPath { get; set; }
 
     /// <summary>
-    ///  Gets or sets the locale of the output file.
+    ///  Gets or sets the laguage of the output files.
     /// </summary>
-    public required CultureInfo OutputFileLocale { get; set; }
+    public required CultureInfo[] OutputFileLanguages { get; set; }
 
     /// <summary>
     ///  Gets or sets the log level.
@@ -55,10 +55,10 @@ public class Settings
             ? $"{new string('*', this.Token.Length - 5)}{this.Token[^5..]}"
             : new string('*', this.Token.Length);
         return $"{nameof(this.Token)}: {tokenDisplay}, " +
-            $"{nameof(this.IntelliSenseDocumentPath)}: {this.IntelliSenseDocumentPath}, " +
-            $"{nameof(this.IntelliSenseDocumentLocale)}: {this.IntelliSenseDocumentLocale}, " +
-            $"{nameof(this.OutputFilePath)}: {this.OutputFilePath}, " +
-            $"{nameof(this.OutputFileLocale)}: {this.OutputFileLocale}, " +
+            $"{nameof(this.SourceDocumentPath)}: {this.SourceDocumentPath}, " +
+            $"{nameof(this.SourceDocumentLanguage)}: {this.SourceDocumentLanguage}, " +
+            $"{nameof(this.OutputDirectoryPath)}: {this.OutputDirectoryPath}, " +
+            $"{nameof(this.OutputFileLanguages)}: {this.OutputFileLanguages}, " +
             $"{nameof(this.LogLevel)}: {this.LogLevel}, " +
             $"{nameof(this.ChatEndPointUrl)}: {this.ChatEndPointUrl}, " +
             $"{nameof(this.ModelId)}: {this.ModelId}";

--- a/src/TsunaCan.XmlDocumentationTranslator.Core/Settings.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.Core/Settings.cs
@@ -65,5 +65,5 @@ public class Settings
     }
 
     private string OutputFileLanguagesString()
-        => $"[{string.Join(',', this.OutputFileLanguages.Select(c => c.Name))}]";
+        => $"[{string.Join(',', this.OutputFileLanguages.Select(c => c.EnglishName))}]";
 }

--- a/src/TsunaCan.XmlDocumentationTranslator.Core/Settings.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.Core/Settings.cs
@@ -58,9 +58,12 @@ public class Settings
             $"{nameof(this.SourceDocumentPath)}: {this.SourceDocumentPath}, " +
             $"{nameof(this.SourceDocumentLanguage)}: {this.SourceDocumentLanguage}, " +
             $"{nameof(this.OutputDirectoryPath)}: {this.OutputDirectoryPath}, " +
-            $"{nameof(this.OutputFileLanguages)}: {this.OutputFileLanguages}, " +
+            $"{nameof(this.OutputFileLanguages)}: {this.OutputFileLanguagesString()}, " +
             $"{nameof(this.LogLevel)}: {this.LogLevel}, " +
             $"{nameof(this.ChatEndPointUrl)}: {this.ChatEndPointUrl}, " +
             $"{nameof(this.ModelId)}: {this.ModelId}";
     }
+
+    private string OutputFileLanguagesString()
+        => $"[{string.Join(',', this.OutputFileLanguages.Select(c => c.Name))}]";
 }

--- a/src/TsunaCan.XmlDocumentationTranslator.Core/Settings.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.Core/Settings.cs
@@ -29,7 +29,7 @@ public class Settings
     public required string OutputDirectoryPath { get; set; }
 
     /// <summary>
-    ///  Gets or sets the laguage of the output files.
+    ///  Gets or sets the language of the output files.
     /// </summary>
     public required CultureInfo[] OutputFileLanguages { get; set; }
 

--- a/src/TsunaCan.XmlDocumentationTranslator.Core/TranslationService.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.Core/TranslationService.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.Extensions.Logging;
+using TsunaCan.XmlDocumentationTranslator.IntelliSense;
+using TsunaCan.XmlDocumentationTranslator.Resources;
+
+namespace TsunaCan.XmlDocumentationTranslator;
+
+/// <summary>
+///  Service for translating IntelliSense XML documentation files.
+/// </summary>
+public class TranslationService
+{
+    private readonly IIntelliSenseDocumentManager documentManager;
+    private readonly ITranslator translator;
+    private readonly Settings settings;
+    private readonly ILogger<TranslationService> logger;
+
+    /// <summary>
+    ///  Initializes a new instance of the <see cref="TranslationService"/> class.
+    /// </summary>
+    /// <param name="documentManager">IntelliSense XML documentation file manager.</param>
+    /// <param name="translator">Translating XML documentation files.</param>
+    /// <param name="settings">Translating settings.</param>
+    /// <param name="logger">Logger.</param>
+    public TranslationService(
+        IIntelliSenseDocumentManager documentManager,
+        ITranslator translator,
+        Settings settings,
+        ILogger<TranslationService> logger)
+    {
+        this.documentManager = documentManager;
+        this.translator = translator;
+        this.settings = settings;
+        this.logger = logger;
+    }
+
+    /// <summary>
+    ///  Execute the translation process.
+    /// </summary>
+    /// <returns>Task.</returns>
+    public async Task ExecuteAsync()
+    {
+        this.logger.LogInformation(Messages.DumpSettings, this.settings.ToString());
+        var document = this.documentManager.Read(this.settings.SourceDocumentPath);
+        var translatedDocument = await this.translator.TranslateAsync(document, this.settings.SourceDocumentLanguage, this.settings.OutputFileLanguages);
+
+        var baseFilePath = this.settings.OutputDirectoryPath;
+        List<string> outputFiles = [];
+        foreach (var result in translatedDocument)
+        {
+            var outputFilePath = Path.Combine(baseFilePath, result.Key.Name, this.settings.SourceDocumentPath);
+            outputFiles.Add(outputFilePath);
+            this.documentManager.Write(outputFilePath, result.Value);
+        }
+
+        var outputFilePaths = $"[{string.Join(", ", outputFiles)}]";
+        this.logger.LogInformation(Messages.Translated, outputFiles.Count, outputFilePaths);
+    }
+}

--- a/tests/Test.TsunaCan.XmlDocumentationTranslator.Core/IntelliSense/IntelliSenseDocumentManagerTest.cs
+++ b/tests/Test.TsunaCan.XmlDocumentationTranslator.Core/IntelliSense/IntelliSenseDocumentManagerTest.cs
@@ -368,7 +368,7 @@ public class IntelliSenseDocumentManagerTest(ITestOutputHelper testOutputHelper)
 
             // Assert
             var logCollector = this.loggerManager.LogCollector;
-            Assert.Equal(1, logCollector.Count);
+            Assert.Equal(2, logCollector.Count);
             var record = logCollector.LatestRecord;
             Assert.Equal(LogLevel.Information, record.Level);
             Assert.Equal($"Xml document {tempFilePath} was created.", record.Message);
@@ -401,8 +401,8 @@ public class IntelliSenseDocumentManagerTest(ITestOutputHelper testOutputHelper)
 
             // Assert
             var logCollector = this.loggerManager.LogCollector;
-            Assert.Equal(2, logCollector.Count);
-            var record = logCollector.GetSnapshot()[0];
+            Assert.Equal(3, logCollector.Count);
+            var record = logCollector.GetSnapshot()[1];
             Assert.Equal(LogLevel.Information, record.Level);
             Assert.Equal($"Directory {directoryPath} was created.", record.Message);
         }

--- a/tests/Test.TsunaCan.XmlDocumentationTranslator.Core/IntelliSense/IntelliSenseDocumentManagerTest.cs
+++ b/tests/Test.TsunaCan.XmlDocumentationTranslator.Core/IntelliSense/IntelliSenseDocumentManagerTest.cs
@@ -388,8 +388,9 @@ public class IntelliSenseDocumentManagerTest(ITestOutputHelper testOutputHelper)
         {
             Assembly = new() { Name = string.Empty },
         };
-        var tempFilePath = Path.Combine(Path.GetTempPath(), "DUMMY_DIR", Path.GetRandomFileName());
+        var tempFilePath = Path.Combine(Path.GetTempPath(), "DUMMY_DIR", "SUB_DIR", Path.GetRandomFileName());
         var directoryPath = Path.GetDirectoryName(tempFilePath);
+        var rootDirectory = Path.GetDirectoryName(directoryPath);
         try
         {
             var logger = this.loggerManager.CreateLogger<IntelliSenseDocumentManager>();
@@ -409,9 +410,9 @@ public class IntelliSenseDocumentManagerTest(ITestOutputHelper testOutputHelper)
         {
             // Cleanup
             File.Delete(tempFilePath);
-            if (Directory.Exists(directoryPath))
+            if (Directory.Exists(rootDirectory))
             {
-                Directory.Delete(directoryPath, true);
+                Directory.Delete(rootDirectory, true);
             }
         }
     }

--- a/tests/Test.TsunaCan.XmlDocumentationTranslator.Core/SettingsTest.cs
+++ b/tests/Test.TsunaCan.XmlDocumentationTranslator.Core/SettingsTest.cs
@@ -29,7 +29,7 @@ public class SettingsTest
                        "SourceDocumentPath: path/to/document, " +
                        "SourceDocumentLanguage: en-US, " +
                        "OutputDirectoryPath: path/to/output, " +
-                       "OutputFileLanguages: [ja-JP], " +
+                       "OutputFileLanguages: [Japanese (Japan)], " +
                        "LogLevel: Information, " +
                        "ChatEndPointUrl: https://example.com/, " +
                        "ModelId: model-id";
@@ -60,7 +60,7 @@ public class SettingsTest
                        "SourceDocumentPath: path/to/document, " +
                        "SourceDocumentLanguage: en-US, " +
                        "OutputDirectoryPath: path/to/output, " +
-                       "OutputFileLanguages: [ja-JP], " +
+                       "OutputFileLanguages: [Japanese (Japan)], " +
                        "LogLevel: Information, " +
                        "ChatEndPointUrl: https://example.com/, " +
                        "ModelId: model-id";
@@ -91,7 +91,7 @@ public class SettingsTest
                        "SourceDocumentPath: path/to/document, " +
                        "SourceDocumentLanguage: en-US, " +
                        "OutputDirectoryPath: path/to/output, " +
-                       "OutputFileLanguages: [ja,es], " +
+                       "OutputFileLanguages: [Japanese,Spanish], " +
                        "LogLevel: Information, " +
                        "ChatEndPointUrl: https://example.com/, " +
                        "ModelId: model-id";

--- a/tests/Test.TsunaCan.XmlDocumentationTranslator.Core/SettingsTest.cs
+++ b/tests/Test.TsunaCan.XmlDocumentationTranslator.Core/SettingsTest.cs
@@ -119,9 +119,7 @@ public class SettingsTest
         Assert.Equal("test-path", settings.SourceDocumentPath);
         Assert.Equal(new CultureInfo("fr-FR"), settings.SourceDocumentLanguage);
         Assert.Equal("output-path", settings.OutputDirectoryPath);
-        Assert.Collection(
-            settings.OutputFileLanguages,
-            item => Assert.Equal(new CultureInfo("de-DE"), item));
+        Assert.Single(settings.OutputFileLanguages, new CultureInfo("de-DE"));
         Assert.Equal(LogLevel.Debug, settings.LogLevel);
         Assert.Equal(new Uri("https://test.com"), settings.ChatEndPointUrl);
         Assert.Equal("test-model", settings.ModelId);

--- a/tests/Test.TsunaCan.XmlDocumentationTranslator.Core/SettingsTest.cs
+++ b/tests/Test.TsunaCan.XmlDocumentationTranslator.Core/SettingsTest.cs
@@ -26,10 +26,10 @@ public class SettingsTest
 
         // Assert
         var expected = "Token: ******7890a, " +
-                       "IntelliSenseDocumentPath: path/to/document, " +
-                       "IntelliSenseDocumentLocale: en-US, " +
-                       "OutputFilePath: path/to/output, " +
-                       "OutputFileLocale: ja-JP, " +
+                       "SourceDocumentPath: path/to/document, " +
+                       "SourceDocumentLanguage: en-US, " +
+                       "OutputDirectoryPath: path/to/output, " +
+                       "OutputFileLanguages: [ja-JP], " +
                        "LogLevel: Information, " +
                        "ChatEndPointUrl: https://example.com/, " +
                        "ModelId: model-id";
@@ -57,10 +57,41 @@ public class SettingsTest
 
         // Assert
         var expected = "Token: **********, " +
-                       "IntelliSenseDocumentPath: path/to/document, " +
-                       "IntelliSenseDocumentLocale: en-US, " +
-                       "OutputFilePath: path/to/output, " +
-                       "OutputFileLocale: ja-JP, " +
+                       "SourceDocumentPath: path/to/document, " +
+                       "SourceDocumentLanguage: en-US, " +
+                       "OutputDirectoryPath: path/to/output, " +
+                       "OutputFileLanguages: [ja-JP], " +
+                       "LogLevel: Information, " +
+                       "ChatEndPointUrl: https://example.com/, " +
+                       "ModelId: model-id";
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ToString_MultipleOutputFileLnaguages()
+    {
+        // Arrange
+        var settings = new Settings
+        {
+            Token = "1234567890",
+            SourceDocumentPath = "path/to/document",
+            SourceDocumentLanguage = new CultureInfo("en-US"),
+            OutputDirectoryPath = "path/to/output",
+            OutputFileLanguages = [new CultureInfo("ja"), new CultureInfo("es")],
+            LogLevel = LogLevel.Information,
+            ChatEndPointUrl = new Uri("https://example.com/"),
+            ModelId = "model-id",
+        };
+
+        // Act
+        var result = settings.ToString();
+
+        // Assert
+        var expected = "Token: **********, " +
+                       "SourceDocumentPath: path/to/document, " +
+                       "SourceDocumentLanguage: en-US, " +
+                       "OutputDirectoryPath: path/to/output, " +
+                       "OutputFileLanguages: [ja,es], " +
                        "LogLevel: Information, " +
                        "ChatEndPointUrl: https://example.com/, " +
                        "ModelId: model-id";

--- a/tests/Test.TsunaCan.XmlDocumentationTranslator.Core/SettingsTest.cs
+++ b/tests/Test.TsunaCan.XmlDocumentationTranslator.Core/SettingsTest.cs
@@ -68,7 +68,7 @@ public class SettingsTest
     }
 
     [Fact]
-    public void ToString_MultipleOutputFileLnaguages()
+    public void ToString_MultipleOutputFileLanguages()
     {
         // Arrange
         var settings = new Settings

--- a/tests/Test.TsunaCan.XmlDocumentationTranslator.Core/SettingsTest.cs
+++ b/tests/Test.TsunaCan.XmlDocumentationTranslator.Core/SettingsTest.cs
@@ -12,10 +12,10 @@ public class SettingsTest
         var settings = new Settings
         {
             Token = "1234567890a",
-            IntelliSenseDocumentPath = "path/to/document",
-            IntelliSenseDocumentLocale = new CultureInfo("en-US"),
-            OutputFilePath = "path/to/output",
-            OutputFileLocale = new CultureInfo("ja-JP"),
+            SourceDocumentPath = "path/to/document",
+            SourceDocumentLanguage = new CultureInfo("en-US"),
+            OutputDirectoryPath = "path/to/output",
+            OutputFileLanguages = [new CultureInfo("ja-JP")],
             LogLevel = LogLevel.Information,
             ChatEndPointUrl = new Uri("https://example.com/"),
             ModelId = "model-id",
@@ -43,10 +43,10 @@ public class SettingsTest
         var settings = new Settings
         {
             Token = "1234567890",
-            IntelliSenseDocumentPath = "path/to/document",
-            IntelliSenseDocumentLocale = new CultureInfo("en-US"),
-            OutputFilePath = "path/to/output",
-            OutputFileLocale = new CultureInfo("ja-JP"),
+            SourceDocumentPath = "path/to/document",
+            SourceDocumentLanguage = new CultureInfo("en-US"),
+            OutputDirectoryPath = "path/to/output",
+            OutputFileLanguages = [new CultureInfo("ja-JP")],
             LogLevel = LogLevel.Information,
             ChatEndPointUrl = new Uri("https://example.com/"),
             ModelId = "model-id",
@@ -74,10 +74,10 @@ public class SettingsTest
         var settings = new Settings
         {
             Token = "test-token",
-            IntelliSenseDocumentPath = "test-path",
-            IntelliSenseDocumentLocale = new CultureInfo("fr-FR"),
-            OutputFilePath = "output-path",
-            OutputFileLocale = new CultureInfo("de-DE"),
+            SourceDocumentPath = "test-path",
+            SourceDocumentLanguage = new CultureInfo("fr-FR"),
+            OutputDirectoryPath = "output-path",
+            OutputFileLanguages = [new CultureInfo("de-DE")],
             LogLevel = LogLevel.Debug,
             ChatEndPointUrl = new Uri("https://test.com"),
             ModelId = "test-model",
@@ -85,10 +85,12 @@ public class SettingsTest
 
         // Assert
         Assert.Equal("test-token", settings.Token);
-        Assert.Equal("test-path", settings.IntelliSenseDocumentPath);
-        Assert.Equal(new CultureInfo("fr-FR"), settings.IntelliSenseDocumentLocale);
-        Assert.Equal("output-path", settings.OutputFilePath);
-        Assert.Equal(new CultureInfo("de-DE"), settings.OutputFileLocale);
+        Assert.Equal("test-path", settings.SourceDocumentPath);
+        Assert.Equal(new CultureInfo("fr-FR"), settings.SourceDocumentLanguage);
+        Assert.Equal("output-path", settings.OutputDirectoryPath);
+        Assert.Collection(
+            settings.OutputFileLanguages,
+            item => Assert.Equal(new CultureInfo("de-DE"), item));
         Assert.Equal(LogLevel.Debug, settings.LogLevel);
         Assert.Equal(new Uri("https://test.com"), settings.ChatEndPointUrl);
         Assert.Equal("test-model", settings.ModelId);

--- a/tests/Test.TsunaCan.XmlDocumentationTranslator.Core/Test.TsunaCan.XmlDocumentationTranslator.Core.csproj
+++ b/tests/Test.TsunaCan.XmlDocumentationTranslator.Core/Test.TsunaCan.XmlDocumentationTranslator.Core.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Maris.Logging.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>

--- a/tests/Test.TsunaCan.XmlDocumentationTranslator.Core/TranslationServiceTest.cs
+++ b/tests/Test.TsunaCan.XmlDocumentationTranslator.Core/TranslationServiceTest.cs
@@ -32,6 +32,9 @@ public class TranslationServiceTest(ITestOutputHelper testOutputHelper)
         documentManagerMock
             .Setup(dm => dm.Read(It.IsAny<string>()))
             .Returns(documentAccessor);
+        documentManagerMock
+            .Setup(dm => dm.Write(It.IsAny<string>(), It.IsAny<IntelliSenseDocument>()))
+            .Verifiable();
         var translatorMock = new Mock<ITranslator>();
         translatorMock.Setup(t => t.TranslateAsync(It.IsAny<IntelliSenseDocumentAccessor>(), It.IsAny<CultureInfo>(), It.IsAny<IReadOnlyList<CultureInfo>>()))
             .ReturnsAsync(new Dictionary<CultureInfo, IntelliSenseDocument>
@@ -60,6 +63,13 @@ public class TranslationServiceTest(ITestOutputHelper testOutputHelper)
         Assert.Equal(2, this.loggerManager.LogCollector.Count);
         var record = this.loggerManager.LogCollector.LatestRecord;
         Assert.Equal(LogLevel.Information, record.Level);
-        Assert.Contains("[output\\fr\\source.xml, output\\es\\source.xml]", record.Message);
+        Assert.Contains($"[{Path.Combine("output", "fr", "source.xml")}, {Path.Combine("output", "es", "source.xml")}]", record.Message);
+
+        documentManagerMock.Verify(
+            dm => dm.Write(Path.Combine("output", "fr", "source.xml"), It.IsAny<IntelliSenseDocument>()),
+            Times.Once);
+        documentManagerMock.Verify(
+            dm => dm.Write(Path.Combine("output", "es", "source.xml"), It.IsAny<IntelliSenseDocument>()),
+            Times.Once);
     }
 }

--- a/tests/Test.TsunaCan.XmlDocumentationTranslator.Core/TranslationServiceTest.cs
+++ b/tests/Test.TsunaCan.XmlDocumentationTranslator.Core/TranslationServiceTest.cs
@@ -1,0 +1,65 @@
+﻿using System.Globalization;
+using System.Xml.Linq;
+using Maris.Logging.Testing.Xunit;
+using Microsoft.Extensions.Logging;
+using Moq;
+using TsunaCan.XmlDocumentationTranslator.IntelliSense;
+
+namespace TsunaCan.XmlDocumentationTranslator;
+
+public class TranslationServiceTest(ITestOutputHelper testOutputHelper)
+{
+    private readonly TestLoggerManager loggerManager = new(testOutputHelper);
+
+    [Fact]
+    public async Task ExecuteAsync_OutputFilesArePlacedInLanguageSpecificDirectories()
+    {
+        // Arrange
+        var documentManagerMock = new Mock<IIntelliSenseDocumentManager>();
+        var documentAccessor = new IntelliSenseDocumentAccessor(
+            XDocument.Parse("""
+                <doc>
+                    <assembly>
+                        <name>TestAssembly</name>
+                    </assembly>
+                    <members>
+                        <member name="T:TestClass">
+                            <summary>Test class summary</summary>
+                        </member>
+                    </members>
+                </doc>
+                """));
+        documentManagerMock
+            .Setup(dm => dm.Read(It.IsAny<string>()))
+            .Returns(documentAccessor);
+        var translatorMock = new Mock<ITranslator>();
+        translatorMock.Setup(t => t.TranslateAsync(It.IsAny<IntelliSenseDocumentAccessor>(), It.IsAny<CultureInfo>(), It.IsAny<IReadOnlyList<CultureInfo>>()))
+            .ReturnsAsync(new Dictionary<CultureInfo, IntelliSenseDocument>
+            {
+                [new CultureInfo("fr")] = new IntelliSenseDocument() { Assembly = new Assembly() { Name = "TestAssembly" } },
+                [new CultureInfo("es")] = new IntelliSenseDocument() { Assembly = new Assembly() { Name = "TestAssembly" } },
+            });
+        var settings = new Settings
+        {
+            Token = string.Empty,
+            SourceDocumentPath = "source.xml",
+            SourceDocumentLanguage = new CultureInfo("en"),
+            OutputDirectoryPath = "output",
+            OutputFileLanguages = [new CultureInfo("fr"), new CultureInfo("es")],
+            ChatEndPointUrl = new Uri("https://example.com"),
+            ModelId = "model-id",
+            LogLevel = LogLevel.Information,
+        };
+        var logger = this.loggerManager.CreateLogger<TranslationService>();
+        var service = new TranslationService(documentManagerMock.Object, translatorMock.Object, settings, logger);
+
+        // Act
+        await service.ExecuteAsync();
+
+        // Assert
+        Assert.Equal(2, this.loggerManager.LogCollector.Count);
+        var record = this.loggerManager.LogCollector.LatestRecord;
+        Assert.Equal(LogLevel.Information, record.Level);
+        Assert.Contains("[output\\fr\\source.xml, output\\es\\source.xml]", record.Message);
+    }
+}


### PR DESCRIPTION
## この Pull request で実施したこと

- `IntelliSenseDocumentManager` のインターフェース `IIntelliSenseDocumentManager` を追加しました。
- `ITranslator` インターフェースを追加しました。
- `IntelliSenseDocumentAccessor` を `public` に変更しました。
- `Settings` の構造を見直しました。
- `TranslationService` を追加しました。

## この Pull request では実施していないこと

翻訳処理そのものは追加していません。

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし