### PR TITLE
依存パッケージのバージョンを更新

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,15 +1,15 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="Maris.Logging.Testing" Version="1.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.AI" Version="9.4.3-preview.1.25230.7" />
-    <PackageVersion Include="Microsoft.Extensions.AI.AzureAIInference" Version="9.4.3-preview.1.25230.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.AI" Version="9.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.AI.AzureAIInference" Version="9.5.0-preview.1.25265.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
     <PackageVersion Include="Moq" Version="4.20.72" />


### PR DESCRIPTION
## この Pull request で実施したこと

`Directory.Packages.props` ファイルにおいて、以下のパッケージのバージョンを更新しました：
- `Microsoft.Extensions.AI` と `Microsoft.Extensions.AI.AzureAIInference` をそれぞれ `9.4.3-preview.1.25230.7` から `9.5.0` および `9.4.3-preview.1.25230.7` から `9.5.0-preview.1.25265.7` に変更。
- `Microsoft.Extensions.Configuration.Abstractions`、`Microsoft.Extensions.Hosting`、`Microsoft.Extensions.Options`、`Microsoft.Extensions.Options.ConfigurationExtensions`、`Microsoft.Extensions.Options.DataAnnotations` のバージョンを `9.0.4` から `9.0.5` に更新。
- `Microsoft.NET.Test.Sdk` のバージョンを `17.13.0` から `17.14.0` に変更。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし