### PR TITLE
AIのターゲットをnetstandard2.0に変更する

### DIFF
--- a/src/TsunaCan.XmlDocumentationTranslator.AI/AISettings.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.AI/AISettings.cs
@@ -8,7 +8,7 @@
         /// <summary>
         ///  Gets or sets the authentication token.
         /// </summary>
-        public required string Token { get; set; }
+        public string Token { get; set; }
 
         /// <summary>
         ///  Gets or sets the chat endpoint URL.

--- a/src/TsunaCan.XmlDocumentationTranslator.AI/AISettings.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.AI/AISettings.cs
@@ -1,49 +1,50 @@
-﻿namespace TsunaCan.XmlDocumentationTranslator.AI;
-
-/// <summary>
-///  Represents the AI translator application settings.
-/// </summary>
-public class AISettings
+﻿namespace TsunaCan.XmlDocumentationTranslator.AI
 {
     /// <summary>
-    ///  Gets or sets the authentication token.
+    ///  Represents the AI translator application settings.
     /// </summary>
-    public required string Token { get; set; }
-
-    /// <summary>
-    ///  Gets or sets the chat endpoint URL.
-    ///  Default is "https://models.inference.ai.azure.com".
-    /// </summary>
-    public Uri ChatEndPointUrl { get; set; } = new Uri("https://models.inference.ai.azure.com");
-
-    /// <summary>
-    ///  Gets or sets the model ID to be used.
-    ///  Default is "gpt-4.1-mini".
-    /// </summary>
-    public string ModelId { get; set; } = "gpt-4.1-mini";
-
-    /// <summary>
-    ///  Gets or sets the chunk size for the translation process.
-    ///  Default is 4000.
-    /// </summary>
-    public int ChunkSize { get; set; } = 4000;
-
-    /// <summary>
-    ///  Gets or sets the maximum number of concurrent requests for AI translation.
-    ///  Default is 5.
-    /// </summary>
-    public int MaxConcurrentRequests { get; set; } = 5;
-
-    /// <inheritdoc/>
-    public override string ToString()
+    public class AISettings
     {
-        string tokenDisplay = this.Token.Length > 10
-            ? $"{new string('*', this.Token.Length - 5)}{this.Token[^5..]}"
-            : new string('*', this.Token.Length);
-        return $"{nameof(this.Token)}: {tokenDisplay}, " +
-            $"{nameof(this.ChatEndPointUrl)}: {this.ChatEndPointUrl}, " +
-            $"{nameof(this.ModelId)}: {this.ModelId}, " +
-            $"{nameof(this.ChunkSize)}: {this.ChunkSize}, " +
-            $"{nameof(this.MaxConcurrentRequests)}: {this.MaxConcurrentRequests}";
+        /// <summary>
+        ///  Gets or sets the authentication token.
+        /// </summary>
+        public required string Token { get; set; }
+
+        /// <summary>
+        ///  Gets or sets the chat endpoint URL.
+        ///  Default is "https://models.inference.ai.azure.com".
+        /// </summary>
+        public Uri ChatEndPointUrl { get; set; } = new Uri("https://models.inference.ai.azure.com");
+
+        /// <summary>
+        ///  Gets or sets the model ID to be used.
+        ///  Default is "gpt-4.1-mini".
+        /// </summary>
+        public string ModelId { get; set; } = "gpt-4.1-mini";
+
+        /// <summary>
+        ///  Gets or sets the chunk size for the translation process.
+        ///  Default is 4000.
+        /// </summary>
+        public int ChunkSize { get; set; } = 4000;
+
+        /// <summary>
+        ///  Gets or sets the maximum number of concurrent requests for AI translation.
+        ///  Default is 5.
+        /// </summary>
+        public int MaxConcurrentRequests { get; set; } = 5;
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            string tokenDisplay = this.Token.Length > 10
+                ? $"{new string('*', this.Token.Length - 5)}{this.Token[^5..]}"
+                : new string('*', this.Token.Length);
+            return $"{nameof(this.Token)}: {tokenDisplay}, " +
+                $"{nameof(this.ChatEndPointUrl)}: {this.ChatEndPointUrl}, " +
+                $"{nameof(this.ModelId)}: {this.ModelId}, " +
+                $"{nameof(this.ChunkSize)}: {this.ChunkSize}, " +
+                $"{nameof(this.MaxConcurrentRequests)}: {this.MaxConcurrentRequests}";
+        }
     }
 }

--- a/src/TsunaCan.XmlDocumentationTranslator.AI/AISettings.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.AI/AISettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using TsunaCan.XmlDocumentationTranslator.AI.Resources;
 
 namespace TsunaCan.XmlDocumentationTranslator.AI
 {
@@ -7,34 +8,101 @@ namespace TsunaCan.XmlDocumentationTranslator.AI
     /// </summary>
     public class AISettings
     {
+        private string token = string.Empty;
+        private Uri chatEndPointUrl = new Uri("https://models.inference.ai.azure.com");
+        private string modelId = "gpt-4.1-mini";
+        private int chunkSize = 4000;
+        private int maxConcurrentRequests = 5;
+
         /// <summary>
         ///  Gets or sets the authentication token.
         /// </summary>
-        public string Token { get; set; }
+        /// <exception cref="ArgumentNullException">
+        ///  <list type="bullet">
+        ///   <item>Thrown when the value is null.</item>
+        ///  </list>
+        /// </exception>
+        public string Token
+        {
+            get => this.token;
+            set => this.token = value ?? throw new ArgumentNullException(nameof(value));
+        }
 
         /// <summary>
         ///  Gets or sets the chat endpoint URL.
         ///  Default is "https://models.inference.ai.azure.com".
         /// </summary>
-        public Uri ChatEndPointUrl { get; set; } = new Uri("https://models.inference.ai.azure.com");
+        /// <exception cref="ArgumentNullException">
+        ///  <list type="bullet">
+        ///   <item>Thrown when the value is null.</item>
+        ///  </list>
+        /// </exception>
+        public Uri ChatEndPointUrl
+        {
+            get => this.chatEndPointUrl;
+            set => this.chatEndPointUrl = value ?? throw new ArgumentNullException(nameof(value));
+        }
 
         /// <summary>
         ///  Gets or sets the model ID to be used.
         ///  Default is "gpt-4.1-mini".
         /// </summary>
-        public string ModelId { get; set; } = "gpt-4.1-mini";
+        /// <exception cref="ArgumentNullException">
+        ///  <list type="bullet">
+        ///   <item>Thrown when the value is null.</item>
+        ///  </list>
+        /// </exception>
+        public string ModelId
+        {
+            get => this.modelId;
+            set => this.modelId = value ?? throw new ArgumentNullException(nameof(value));
+        }
 
         /// <summary>
         ///  Gets or sets the chunk size for the translation process.
         ///  Default is 4000.
         /// </summary>
-        public int ChunkSize { get; set; } = 4000;
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///  <list type="bullet">
+        ///   <item>Chunk size must be greater than zero.</item>
+        ///  </list>
+        /// </exception>
+        public int ChunkSize
+        {
+            get => this.chunkSize;
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), Messages.ChunkSizeMustBeGreaterThanZero);
+                }
+
+                this.chunkSize = value;
+            }
+        }
 
         /// <summary>
         ///  Gets or sets the maximum number of concurrent requests for AI translation.
         ///  Default is 5.
         /// </summary>
-        public int MaxConcurrentRequests { get; set; } = 5;
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///  <list type="bullet">
+        ///   <item>Max concurrent requests must be greater than zero.</item>
+        ///  </list>
+        /// </exception>
+        public int MaxConcurrentRequests
+        {
+            get => this.maxConcurrentRequests;
+            set
+            {
+                if (value <= 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), Messages.MaxConcurrentRequestsMustBeGreaterThanZero);
+                }
+
+                this.maxConcurrentRequests = value;
+            }
+        }
 
         /// <inheritdoc/>
         public override string ToString()

--- a/src/TsunaCan.XmlDocumentationTranslator.AI/AISettings.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.AI/AISettings.cs
@@ -25,7 +25,7 @@ namespace TsunaCan.XmlDocumentationTranslator.AI
         public string Token
         {
             get => this.token;
-            set => this.token = value ?? throw new ArgumentNullException(nameof(value));
+            set => this.token = value ?? throw new ArgumentNullException(nameof(this.Token));
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace TsunaCan.XmlDocumentationTranslator.AI
         public Uri ChatEndPointUrl
         {
             get => this.chatEndPointUrl;
-            set => this.chatEndPointUrl = value ?? throw new ArgumentNullException(nameof(value));
+            set => this.chatEndPointUrl = value ?? throw new ArgumentNullException(nameof(this.ChatEndPointUrl));
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace TsunaCan.XmlDocumentationTranslator.AI
         public string ModelId
         {
             get => this.modelId;
-            set => this.modelId = value ?? throw new ArgumentNullException(nameof(value));
+            set => this.modelId = value ?? throw new ArgumentNullException(nameof(this.ModelId));
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace TsunaCan.XmlDocumentationTranslator.AI
             {
                 if (value <= 0)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), Messages.ChunkSizeMustBeGreaterThanZero);
+                    throw new ArgumentOutOfRangeException(nameof(this.ChunkSize), Messages.ChunkSizeMustBeGreaterThanZero);
                 }
 
                 this.chunkSize = value;
@@ -97,7 +97,7 @@ namespace TsunaCan.XmlDocumentationTranslator.AI
             {
                 if (value <= 0)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), Messages.MaxConcurrentRequestsMustBeGreaterThanZero);
+                    throw new ArgumentOutOfRangeException(nameof(this.MaxConcurrentRequests), Messages.MaxConcurrentRequestsMustBeGreaterThanZero);
                 }
 
                 this.maxConcurrentRequests = value;

--- a/src/TsunaCan.XmlDocumentationTranslator.AI/AISettings.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.AI/AISettings.cs
@@ -38,7 +38,7 @@
         public override string ToString()
         {
             string tokenDisplay = this.Token.Length > 10
-                ? $"{new string('*', this.Token.Length - 5)}{this.Token[^5..]}"
+                ? $"{new string('*', this.Token.Length - 5)}{this.Token.Substring(this.Token.Length - 5)}"
                 : new string('*', this.Token.Length);
             return $"{nameof(this.Token)}: {tokenDisplay}, " +
                 $"{nameof(this.ChatEndPointUrl)}: {this.ChatEndPointUrl}, " +

--- a/src/TsunaCan.XmlDocumentationTranslator.AI/AISettings.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.AI/AISettings.cs
@@ -1,4 +1,6 @@
-﻿namespace TsunaCan.XmlDocumentationTranslator.AI
+﻿using System;
+
+namespace TsunaCan.XmlDocumentationTranslator.AI
 {
     /// <summary>
     ///  Represents the AI translator application settings.

--- a/src/TsunaCan.XmlDocumentationTranslator.AI/AITranslator.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.AI/AITranslator.cs
@@ -196,7 +196,7 @@ namespace TsunaCan.XmlDocumentationTranslator.AI
                 var prompt = CreatePrompt(sourceLanguage, targetLanguage);
                 var chatMessage = new ChatMessage(
                     ChatRole.Assistant,
-                    [prompt, new TextContent(xml)]);
+                    new List<AIContent>() { prompt, new TextContent(xml) });
                 try
                 {
                     await this.aiSemaphore.WaitAsync(); // Use instance field

--- a/src/TsunaCan.XmlDocumentationTranslator.AI/AITranslator.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.AI/AITranslator.cs
@@ -133,11 +133,10 @@ namespace TsunaCan.XmlDocumentationTranslator.AI
         private static async Task<Dictionary<CultureInfo, StringBuilder>> WaitTranslationTasksAsync(
             List<Task<TranslateResult>> translationTasks)
         {
+            var results = await Task.WhenAll(translationTasks);
             var translatedXmlDic = new Dictionary<CultureInfo, StringBuilder>();
-
-            await foreach (var task in Task.WhenEach(translationTasks))
+            foreach (var result in results)
             {
-                var result = await task;
                 if (!translatedXmlDic.TryGetValue(result.TargetLanguage, out var value))
                 {
                     translatedXmlDic.Add(result.TargetLanguage, new StringBuilder(result.TranslatedXml));

--- a/src/TsunaCan.XmlDocumentationTranslator.AI/AITranslator.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.AI/AITranslator.cs
@@ -47,7 +47,7 @@ namespace TsunaCan.XmlDocumentationTranslator.AI
         /// <inheritdoc />
         public async Task<Dictionary<CultureInfo, IntelliSenseDocument>> TranslateAsync(
             IntelliSenseDocumentAccessor document,
-            CultureInfo? sourceLanguage,
+            CultureInfo sourceLanguage,
             IEnumerable<CultureInfo> targetLanguages)
         {
             if (targetLanguages == null || !targetLanguages.Any())
@@ -90,7 +90,7 @@ namespace TsunaCan.XmlDocumentationTranslator.AI
                     this.chatClient.Dispose();
                 }
 
-                this.chatClient = null!;
+                this.chatClient = null;
                 this.disposedValue = true;
             }
         }
@@ -138,7 +138,7 @@ namespace TsunaCan.XmlDocumentationTranslator.AI
             return translatedXmlDic;
         }
 
-        private static TextContent CreatePrompt(CultureInfo? sourceLanguage, CultureInfo targetLanguage)
+        private static TextContent CreatePrompt(CultureInfo sourceLanguage, CultureInfo targetLanguage)
         {
             if (sourceLanguage == null)
             {
@@ -172,7 +172,7 @@ namespace TsunaCan.XmlDocumentationTranslator.AI
 
         private List<Task<TranslateResult>> StartTranslationTasks(
             IntelliSenseDocumentAccessor document,
-            CultureInfo? sourceLanguage,
+            CultureInfo sourceLanguage,
             IEnumerable<CultureInfo> targetLanguages)
         {
             var tasks = new List<Task<TranslateResult>>();
@@ -188,7 +188,7 @@ namespace TsunaCan.XmlDocumentationTranslator.AI
             return tasks;
         }
 
-        private Task<TranslateResult> TranslateXmlAsync(string xml, CultureInfo? sourceLanguage, CultureInfo targetLanguage)
+        private Task<TranslateResult> TranslateXmlAsync(string xml, CultureInfo sourceLanguage, CultureInfo targetLanguage)
         {
             return Task.Run<TranslateResult>(async () =>
             {

--- a/src/TsunaCan.XmlDocumentationTranslator.AI/AITranslator.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.AI/AITranslator.cs
@@ -19,6 +19,19 @@ namespace TsunaCan.XmlDocumentationTranslator.AI
     /// </summary>
     public partial class AITranslator : ITranslator, IDisposable
     {
+        private const string NoSourceLangagePromptFronat = "You are a professional .NET library developer.\n" +
+                            "The following XML document is part of the IntelliSense XML documentation that is included in the NuGet package.\n" +
+                            "It represents class and method descriptions, parameters, return values, and exception descriptions.\n" +
+                            "Please translate this XML document into {0}.\n" +
+                            "Please return only the translated XML document.";
+
+        private const string PromptFormat = "You are a professional .NET library developer.\n" +
+                            "The following XML document is part of the IntelliSense XML documentation that is included in the NuGet package.\n" +
+                            "It represents class and method descriptions, parameters, return values, and exception descriptions.\n" +
+                            "This XML document is written in {0}.\n" +
+                            "Please translate this XML document into {1}.\n" +
+                            "Please return only the translated XML document.";
+
         private static readonly Regex XmlCodeBlock = new Regex(@"```(?:xml)\s*(.*?)\s*```", RegexOptions.Singleline);
         private readonly SemaphoreSlim aiSemaphore;
         private readonly AISettings settings;
@@ -142,24 +155,13 @@ namespace TsunaCan.XmlDocumentationTranslator.AI
         {
             if (sourceLanguage == null)
             {
-                return new TextContent($"""
-                You are a professional .NET library developer.
-                The following XML document is part of the IntelliSense XML documentation that is included in the NuGet package.
-                It represents class and method descriptions, parameters, return values, and exception descriptions.
-                Please translate this XML document into {targetLanguage.EnglishName}.
-                Please return only the translated XML document.
-                """);
+                return new TextContent(
+                    string.Format(NoSourceLangagePromptFronat, targetLanguage.EnglishName));
             }
             else
             {
-                return new TextContent($"""
-                You are a professional .NET library developer.
-                The following XML document is part of the IntelliSense XML documentation that is included in the NuGet package.
-                It represents class and method descriptions, parameters, return values, and exception descriptions.
-                This XML document is written in {sourceLanguage.EnglishName}.
-                Please translate this XML document into {targetLanguage.EnglishName}.
-                Please return only the translated XML document.
-                """);
+                return new TextContent(
+                    string.Format(PromptFormat, sourceLanguage.EnglishName, targetLanguage.EnglishName));
             }
         }
 

--- a/src/TsunaCan.XmlDocumentationTranslator.AI/AITranslator.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.AI/AITranslator.cs
@@ -19,7 +19,7 @@ namespace TsunaCan.XmlDocumentationTranslator.AI
     /// </summary>
     public partial class AITranslator : ITranslator, IDisposable
     {
-        private const string NoSourceLangagePromptFronat = "You are a professional .NET library developer.\n" +
+        private const string NoSourceLangagePromptFromat = "You are a professional .NET library developer.\n" +
                             "The following XML document is part of the IntelliSense XML documentation that is included in the NuGet package.\n" +
                             "It represents class and method descriptions, parameters, return values, and exception descriptions.\n" +
                             "Please translate this XML document into {0}.\n" +
@@ -155,7 +155,7 @@ namespace TsunaCan.XmlDocumentationTranslator.AI
             if (sourceLanguage == null)
             {
                 return new TextContent(
-                    string.Format(NoSourceLangagePromptFronat, targetLanguage.EnglishName));
+                    string.Format(NoSourceLangagePromptFromat, targetLanguage.EnglishName));
             }
             else
             {

--- a/src/TsunaCan.XmlDocumentationTranslator.AI/AITranslator.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.AI/AITranslator.cs
@@ -1,6 +1,11 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -14,7 +19,7 @@ namespace TsunaCan.XmlDocumentationTranslator.AI
     /// </summary>
     public partial class AITranslator : ITranslator, IDisposable
     {
-        private static readonly Regex XmlCodeBlock = XmlCodeBlockRegex();
+        private static readonly Regex XmlCodeBlock = new Regex(@"```(?:xml)\s*(.*?)\s*```", RegexOptions.Singleline);
         private readonly SemaphoreSlim aiSemaphore;
         private readonly AISettings settings;
         private readonly ILogger<AITranslator> logger;
@@ -132,9 +137,6 @@ namespace TsunaCan.XmlDocumentationTranslator.AI
 
             return translatedXmlDic;
         }
-
-        [GeneratedRegex(@"```(?:xml)\s*(.*?)\s*```", RegexOptions.Singleline)]
-        private static partial Regex XmlCodeBlockRegex();
 
         private static TextContent CreatePrompt(CultureInfo? sourceLanguage, CultureInfo targetLanguage)
         {

--- a/src/TsunaCan.XmlDocumentationTranslator.AI/AITranslator.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.AI/AITranslator.cs
@@ -19,7 +19,7 @@ namespace TsunaCan.XmlDocumentationTranslator.AI
     /// </summary>
     public partial class AITranslator : ITranslator, IDisposable
     {
-        private const string NoSourceLangagePromptFromat = "You are a professional .NET library developer.\n" +
+        private const string NoSourceLanguagePromptFormat = "You are a professional .NET library developer.\n" +
                             "The following XML document is part of the IntelliSense XML documentation that is included in the NuGet package.\n" +
                             "It represents class and method descriptions, parameters, return values, and exception descriptions.\n" +
                             "Please translate this XML document into {0}.\n" +
@@ -155,7 +155,7 @@ namespace TsunaCan.XmlDocumentationTranslator.AI
             if (sourceLanguage == null)
             {
                 return new TextContent(
-                    string.Format(NoSourceLangagePromptFromat, targetLanguage.EnglishName));
+                    string.Format(NoSourceLanguagePromptFormat, targetLanguage.EnglishName));
             }
             else
             {

--- a/src/TsunaCan.XmlDocumentationTranslator.AI/AITranslator.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.AI/AITranslator.cs
@@ -203,14 +203,14 @@ namespace TsunaCan.XmlDocumentationTranslator.AI
                     var response = await this.chatClient.GetResponseAsync(chatMessage, options);
                     if (XmlCodeBlock.IsMatch(response.Text))
                     {
-                        return new(
+                        return new TranslateResult(
                             targetLanguage,
                             XmlCodeBlock.Match(response.Text).Groups[1].Value);
                     }
                     else
                     {
                         this.logger.LogWarning(Messages.UnexpectedReturnValue, response.Text);
-                        return new(targetLanguage, response.Text);
+                        return new TranslateResult(targetLanguage, response.Text);
                     }
                 }
                 finally
@@ -220,6 +220,17 @@ namespace TsunaCan.XmlDocumentationTranslator.AI
             });
         }
 
-        private record TranslateResult(CultureInfo TargetLanguage, string TranslatedXml);
+        private class TranslateResult
+        {
+            internal TranslateResult(CultureInfo targetLanguage, string translatedXml)
+            {
+                this.TargetLanguage = targetLanguage;
+                this.TranslatedXml = translatedXml;
+            }
+
+            internal CultureInfo TargetLanguage { get; }
+
+            internal string TranslatedXml { get; }
+        }
     }
 }

--- a/src/TsunaCan.XmlDocumentationTranslator.AI/Resources/Messages.Designer.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.AI/Resources/Messages.Designer.cs
@@ -61,6 +61,15 @@ namespace TsunaCan.XmlDocumentationTranslator.AI.Resources {
         }
         
         /// <summary>
+        ///   Chunk size must be greater than zero. に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string ChunkSizeMustBeGreaterThanZero {
+            get {
+                return ResourceManager.GetString("ChunkSizeMustBeGreaterThanZero", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   AISetting variables: {Variables} に類似しているローカライズされた文字列を検索します。
         /// </summary>
         internal static string DumpAISettings {
@@ -84,6 +93,15 @@ namespace TsunaCan.XmlDocumentationTranslator.AI.Resources {
         internal static string DumpMemberCount {
             get {
                 return ResourceManager.GetString("DumpMemberCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Max concurrent requests must be greater than zero. に類似しているローカライズされた文字列を検索します。
+        /// </summary>
+        internal static string MaxConcurrentRequestsMustBeGreaterThanZero {
+            get {
+                return ResourceManager.GetString("MaxConcurrentRequestsMustBeGreaterThanZero", resourceCulture);
             }
         }
         

--- a/src/TsunaCan.XmlDocumentationTranslator.AI/Resources/Messages.resx
+++ b/src/TsunaCan.XmlDocumentationTranslator.AI/Resources/Messages.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ChunkSizeMustBeGreaterThanZero" xml:space="preserve">
+    <value>Chunk size must be greater than zero.</value>
+  </data>
   <data name="DumpAISettings" xml:space="preserve">
     <value>AISetting variables: {Variables}</value>
   </data>
@@ -125,6 +128,9 @@
   </data>
   <data name="DumpMemberCount" xml:space="preserve">
     <value>XML document member count: {MemberCount}</value>
+  </data>
+  <data name="MaxConcurrentRequestsMustBeGreaterThanZero" xml:space="preserve">
+    <value>Max concurrent requests must be greater than zero.</value>
   </data>
   <data name="TargetLanguagesCannotBeEmpty" xml:space="preserve">
     <value>Target languages cannot be empty.</value>

--- a/src/TsunaCan.XmlDocumentationTranslator.AI/ServiceCollectionExtensions.cs
+++ b/src/TsunaCan.XmlDocumentationTranslator.AI/ServiceCollectionExtensions.cs
@@ -5,40 +5,41 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
-namespace TsunaCan.XmlDocumentationTranslator.AI;
-
-/// <summary>
-///  Extension methods for adding AI translation services.
-/// </summary>
-public static class ServiceCollectionExtensions
+namespace TsunaCan.XmlDocumentationTranslator.AI
 {
     /// <summary>
-    ///  Adds AI translation services to the service collection.
+    ///  Extension methods for adding AI translation services.
     /// </summary>
-    /// <param name="services"><see cref="IServiceCollection"/>.</param>
-    /// <param name="configuration"><see cref="IConfiguration"/> objects.</param>
-    /// <returns>Configured <see cref="IServiceCollection"/> object.</returns>
-    public static IServiceCollection AddAITranslator(this IServiceCollection services, IConfiguration configuration)
+    public static class ServiceCollectionExtensions
     {
-        services.AddOptionsWithValidateOnStart<AISettings>()
-            .Bind(configuration)
-            .ValidateDataAnnotations();
-        services.AddSingleton<ITranslator, AITranslator>();
-        services.AddSingleton(provider =>
+        /// <summary>
+        ///  Adds AI translation services to the service collection.
+        /// </summary>
+        /// <param name="services"><see cref="IServiceCollection"/>.</param>
+        /// <param name="configuration"><see cref="IConfiguration"/> objects.</param>
+        /// <returns>Configured <see cref="IServiceCollection"/> object.</returns>
+        public static IServiceCollection AddAITranslator(this IServiceCollection services, IConfiguration configuration)
         {
-            var options = provider.GetRequiredService<IOptions<AISettings>>();
-            return new ChatCompletionsClient(
-                options.Value.ChatEndPointUrl,
-                new AzureKeyCredential(options.Value.Token));
-        });
-        services.AddChatClient(
-            provider =>
+            services.AddOptionsWithValidateOnStart<AISettings>()
+                .Bind(configuration)
+                .ValidateDataAnnotations();
+            services.AddSingleton<ITranslator, AITranslator>();
+            services.AddSingleton(provider =>
             {
                 var options = provider.GetRequiredService<IOptions<AISettings>>();
-                return provider.GetRequiredService<ChatCompletionsClient>()
-                    .AsIChatClient(options.Value.ModelId);
-            })
-        .UseLogging();
-        return services;
+                return new ChatCompletionsClient(
+                    options.Value.ChatEndPointUrl,
+                    new AzureKeyCredential(options.Value.Token));
+            });
+            services.AddChatClient(
+                provider =>
+                {
+                    var options = provider.GetRequiredService<IOptions<AISettings>>();
+                    return provider.GetRequiredService<ChatCompletionsClient>()
+                        .AsIChatClient(options.Value.ModelId);
+                })
+            .UseLogging();
+            return services;
+        }
     }
 }

--- a/src/TsunaCan.XmlDocumentationTranslator.AI/TsunaCan.XmlDocumentationTranslator.AI.csproj
+++ b/src/TsunaCan.XmlDocumentationTranslator.AI/TsunaCan.XmlDocumentationTranslator.AI.csproj
@@ -1,6 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
     <PackageId>TsunaCan.XmlDocumentationTranslator.AI</PackageId>
     <Authors>masatsuna</Authors>
     <Description>

--- a/tests/Test.TsunaCan.XmlDocumentationTranslator.AI/AISettingsTest.cs
+++ b/tests/Test.TsunaCan.XmlDocumentationTranslator.AI/AISettingsTest.cs
@@ -5,6 +5,60 @@ namespace TsunaCan.XmlDocumentationTranslator;
 public class AISettingsTest
 {
     [Fact]
+    public void Token_ShouldThrowArgumentNullException_WhenSetToNull()
+    {
+        // Arrange
+        var settings = new AISettings();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>("value", () => settings.Token = null!);
+    }
+
+    [Fact]
+    public void ChatEndPointUrl_ShouldThrowArgumentNullException_WhenSetToNull()
+    {
+        // Arrange
+        var settings = new AISettings();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>("value", () => settings.ChatEndPointUrl = null!);
+    }
+
+    [Fact]
+    public void ModelId_ShouldThrowArgumentNullException_WhenSetToNull()
+    {
+        // Arrange
+        var settings = new AISettings();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>("value", () => settings.ModelId = null!);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void ChunkSize_ShouldThrowArgumentOutOfRangeException_WhenSetToZeroOrNegative(int value)
+    {
+        // Arrange
+        var settings = new AISettings();
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>("value", () => settings.ChunkSize = value);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void MaxConcurrentRequests_ShouldThrowArgumentOutOfRangeException_WhenSetToZeroOrNegative(int value)
+    {
+        // Arrange
+        var settings = new AISettings();
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>("value", () => settings.MaxConcurrentRequests = value);
+    }
+
+    [Fact]
     public void ToString_ShouldReturnMaskedPartOfToken()
     {
         // Arrange

--- a/tests/Test.TsunaCan.XmlDocumentationTranslator.AI/AISettingsTest.cs
+++ b/tests/Test.TsunaCan.XmlDocumentationTranslator.AI/AISettingsTest.cs
@@ -11,7 +11,7 @@ public class AISettingsTest
         var settings = new AISettings();
 
         // Act & Assert
-        Assert.Throws<ArgumentNullException>("value", () => settings.Token = null!);
+        Assert.Throws<ArgumentNullException>("Token", () => settings.Token = null!);
     }
 
     [Fact]
@@ -21,7 +21,7 @@ public class AISettingsTest
         var settings = new AISettings();
 
         // Act & Assert
-        Assert.Throws<ArgumentNullException>("value", () => settings.ChatEndPointUrl = null!);
+        Assert.Throws<ArgumentNullException>("ChatEndPointUrl", () => settings.ChatEndPointUrl = null!);
     }
 
     [Fact]
@@ -31,7 +31,7 @@ public class AISettingsTest
         var settings = new AISettings();
 
         // Act & Assert
-        Assert.Throws<ArgumentNullException>("value", () => settings.ModelId = null!);
+        Assert.Throws<ArgumentNullException>("ModelId", () => settings.ModelId = null!);
     }
 
     [Theory]
@@ -43,7 +43,8 @@ public class AISettingsTest
         var settings = new AISettings();
 
         // Act & Assert
-        Assert.Throws<ArgumentOutOfRangeException>("value", () => settings.ChunkSize = value);
+        var ex = Assert.Throws<ArgumentOutOfRangeException>("ChunkSize", () => settings.ChunkSize = value);
+        Assert.StartsWith("Chunk size must be greater than zero.", ex.Message);
     }
 
     [Theory]
@@ -55,7 +56,8 @@ public class AISettingsTest
         var settings = new AISettings();
 
         // Act & Assert
-        Assert.Throws<ArgumentOutOfRangeException>("value", () => settings.MaxConcurrentRequests = value);
+        var ex = Assert.Throws<ArgumentOutOfRangeException>("MaxConcurrentRequests", () => settings.MaxConcurrentRequests = value);
+        Assert.StartsWith("Max concurrent requests must be greater than zero.", ex.Message);
     }
 
     [Fact]


### PR DESCRIPTION
## この Pull request で実施したこと

`TsunaCan.XmlDocumentationTranslator.AI` のターゲットフレームワークを.NET Standard 2.0に変更しました。
単体テストを追加しました。
新しいC#でしか使えない構文を、古い形式に書き換えました。

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし