### PR TITLE
Update Microsoft.Extensions.AI.AzureAIInference 9.5.0-preview.1.25265.7 to 9.6.0-preview.1.25310.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <ItemGroup>
     <PackageVersion Include="Maris.Logging.Testing" Version="1.1.0" />
     <PackageVersion Include="Microsoft.Extensions.AI" Version="9.6.0" />
-    <PackageVersion Include="Microsoft.Extensions.AI.AzureAIInference" Version="9.5.0-preview.1.25265.7" />
+    <PackageVersion Include="Microsoft.Extensions.AI.AzureAIInference" Version="9.6.0-preview.1.25310.2" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />


### PR DESCRIPTION
## この Pull request で実施したこと

`Microsoft.Extensions.AI.AzureAIInference` : `9.5.0-preview.1.25265.7* > `9.6.0-preview.1.25310.2`

## この Pull request では実施していないこと

なし

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし