### PR TITLE
README.mdにサードパーティーライセンス情報を追加

### DIFF
--- a/src/TsunaCan.XmlDocumentationTranslator.Cli/README.md
+++ b/src/TsunaCan.XmlDocumentationTranslator.Cli/README.md
@@ -94,6 +94,16 @@ dotnet xml-document-translate \
   --max-concurrent-requests 5
 ```
 
+## Third-Party Licenses
+
+This tool bundles license texts of third-party open source libraries it depends on.
+When distributed as a NuGet package, these license texts are included in the `LICENSES` directory inside the nupkg file.
+The bundled third-party packages and their license information are listed in the `THIRD-PARTY-NOTICES.txt` file.
+This file is included in the nupkg package.
+Note: The `THIRD-PARTY-NOTICES.txt` in this repository always reflects the latest information.
+The file included in each nupkg corresponds to the OSS libraries bundled in that specific version.
+For full license texts, see the files in the `LICENSES` directory of the nupkg.
+
 ## License
 
 This project is licensed under the MIT License.


### PR DESCRIPTION
## この Pull request で実施したこと

This pull request updates the documentation in the `README.md` file for the `TsunaCan.XmlDocumentationTranslator.Cli` project. The key change is the addition of a section about third-party licenses.

## この Pull request では実施していないこと

Added a "Third-Party Licenses" section to the `README.md` file.
This section explains how third-party license texts are bundled with the tool, where to find them in the NuGet package, and how the `THIRD-PARTY-NOTICES.txt` file reflects the latest information about these licenses.

## Issues や Discussions 、関連する Web サイトなどへのリンク

なし